### PR TITLE
make poster check if issue isn't a duplicate

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -30,3 +30,9 @@ Delete this text and replace it with your description.*
 - What server did the bug occur in and when did it occur?
 
 - What ship did the bug occur on and what is it's {hex code}?
+
+---
+
+*Place an X (no spaces) between the brackets to confirm that you have read the line below.*  
+- [ ] **I have searched the closed and open issues to make sure that this problem has not already been reported.**
+


### PR DESCRIPTION
add a checkbox at the bottom to make the user confirm that the issue isn't a duplicate before posting. (hopefully reduce what happens on #suggestions where there are about 15 posts for every request)